### PR TITLE
Add docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+services:
+  database:
+    image: mysql:5.7
+    container_name: "database"
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - 3306:3306
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: testdb
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: root
+  soccer-api:
+    build: ./
+    container_name: "soccer-api"
+    ports:
+      - 5000:5000
+    environment:
+      DATABASE_HOST: localhost
+      DATABASE_USER: root
+      DATABASE_PASSWORD: root
+      DATABASE_NAME: testdb
+    depends_on:
+      - database

--- a/dockerfile
+++ b/dockerfile
@@ -8,4 +8,4 @@ WORKDIR /
 
 CMD npm install && npm build && npm start
 
-EXPOSE 3306
+EXPOSE 5000


### PR DESCRIPTION
Adding a docker compose file, so the API and the MySQL database can run in a container locally, not needing to connect to a remote database.